### PR TITLE
feat(cli): add --on-collision (skip|rename|overwrite) and update README

### DIFF
--- a/Automatizaciones_simples/Python/file_organizer/README.md
+++ b/Automatizaciones_simples/Python/file_organizer/README.md
@@ -1,41 +1,60 @@
-Este archivo está disponible en español e inglés.  
-This file is available in Spanish and English.
-
----
-
 # Organizador de Archivos (File Organizer)
 
-Script de automatización en Python que organiza archivos en una carpeta según su tipo, moviéndolos a subcarpetas específicas. Es multiplataforma (Windows, Linux, macOS) y no requiere dependencias externas.
+Script de automatización en Python que organiza archivos en una carpeta según su tipo, moviéndolos a subcarpetas específicas.  
+Es multiplataforma (Windows, Linux, macOS) y no requiere dependencias externas.
 
 ---
 
 ## Función
 
-- Analiza los archivos de una carpeta especificada por el usuario.
+- Analiza los archivos de una carpeta especificada por el usuario mediante el parámetro `--path`.
 - Detecta su extensión y los clasifica como:
   - Imágenes, Documentos, Videos, Música u Otros.
 - Crea carpetas si no existen.
 - Mueve cada archivo a la carpeta correspondiente.
+- Permite ejecutar en **modo simulación** con `--dry-run`, mostrando lo que haría sin mover nada.
+- Permite **excluir archivos** por patrón con `--exclude` (ejemplo: `*.tmp *.part`).
+  - Si no se especifica, aplica exclusiones por defecto: `*.tmp`, `*.part`, `*.crdownload`, `Thumbs.db`, `.DS_Store`.
 - Muestra un resumen al finalizar.
 
 ---
 
 ## Cómo se usa
 
-1. Ejecutar el script en terminal:
 
-python organizer.py
+Ejecutar el script en terminal:
 
-Ingresar la ruta completa de la carpeta que deseas organizar.
+python organizer.py --path "RUTA/DE/TU/CARPETA"
 
-Ejemplos:
-  -En Windows:
-C:/Users/TuUsuario/Downloads
-  -En Linux o macOS:
-/home/usuario/Descargas
+## Ejemplos
+
+En Windows:
+python organizer.py --path "C:\Users\TuUsuario\Downloads"
+
+En Linux o macOS:
+python organizer.py --path "/home/usuario/Descargas"
+
+## Opciones adicionales
+
+Simulación (dry run):
+python organizer.py --path "C:\Users\TuUsuario\Downloads" --dry-run
+
+Excluir archivos por patrón:
+python organizer.py --path "C:\Users\TuUsuario\Downloads" --exclude *.bak *.old
+
+Manejo de duplicados (--on-collision)
+Define qué hacer si el archivo ya existe en la carpeta de destino:
+  -skip (por defecto): no mueve si existe.
+  -rename: crea un nombre único con sufijo (1), (2), etc.
+  -overwrite: reemplaza el archivo existente.
+
+# Renombrar duplicados
+python organizer.py --path "RUTA/DE/TU/CARPETA" --on-collision rename
+
+# Sobrescribir duplicados
+python organizer.py --path "RUTA/DE/TU/CARPETA" --on-collision overwrite
 
 ## Estructura generada
-
 Carpeta original/
 ├── Images/
 ├── Documents/
@@ -43,54 +62,10 @@ Carpeta original/
 ├── Music/
 └── Others/
 
-Tecnologías utilizadas
-Python3
-
-Módulos estándar: os, shutil
+Python 3
+Módulos estándar: os, shutil, argparse, pathlib, fnmatch
 
 ## Posibles usos
--Ordenar automáticamente carpetas de descargas.
--Clasificar archivos en pendrives o carpetas compartidas.
--Automatizar la limpieza de archivos en equipos personales o de oficina.
-
-----------------------------------------------------------------------------------------
-
-## File Organizer
-Python automation script that organizes files in a folder by type, moving them into specific subfolders. It is cross-platform (Windows, Linux, macOS) and requires no external dependencies.
-
-## What it does
--Scans the files in a folder specified by the user.
--Detects their extensions and classifies them as:
--Images, Documents, Videos, Music, or Others.
--Creates folders if they do not exist.
--Moves each file to the appropriate folder.
--Displays a summary when finished.
-
-## How to use
-Run the script: 
-python organizer.py
-
-Enter the full path of the folder you want to organize.
-
-## Examples:
-
-On Windows: C:/Users/YourUser/Downloads
-On Linux or macOS: /home/youruser/Downloads
-
-## Generated structure
-
-Original folder/
-├── Images/
-├── Documents/
-├── Videos/
-├── Music/
-└── Others/
-
-Technologies used
-Python 3
-Standard modules: os, shutil
-
-## Possible use cases
--Automatically organize download folders.
--Classify files on USB drives or shared folders.
--Automate file cleanup on personal or work computers.
+Ordenar automáticamente carpetas de descargas.
+Clasificar archivos en pendrives o carpetas compartidas.
+Automatizar la limpieza de archivos en equipos personales o de oficina.

--- a/Automatizaciones_simples/Python/file_organizer/organizer.py
+++ b/Automatizaciones_simples/Python/file_organizer/organizer.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import argparse
+import fnmatch
 from pathlib import Path
 
 FILE_TYPES = {
@@ -10,13 +11,57 @@ FILE_TYPES = {
     "Music": [".mp3", ".wav", ".flac"]
 }
 
-def organize_folder(path: str):
+# Exclusiones por defecto
+DEFAULT_EXCLUDES = ["*.tmp", "*.part", "*.crdownload", "Thumbs.db", ".DS_Store"]
+
+def unique_dest(dest_dir: Path, filename: str) -> Path:
+    """Genera un nombre único si el archivo ya existe (para on-collision=rename)."""
+    base = Path(filename).stem
+    ext = Path(filename).suffix
+    cand = dest_dir / filename
+    i = 1
+    while cand.exists():
+        cand = dest_dir / f"{base} ({i}){ext}"
+        i += 1
+    return cand
+
+def move_file(file_path, target_folder, dry_run=False, on_collision="skip"):
+    """Mueve un archivo respetando la política de colisión."""
+    dest_dir = Path(target_folder)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = os.path.basename(file_path)
+    destination = dest_dir / filename
+
+    if destination.exists():
+        if on_collision == "skip":
+            print(f"Skipped (exists): {filename} → {target_folder}")
+            return
+        elif on_collision == "rename":
+            destination = unique_dest(dest_dir, filename)
+            print(f"Renamed: {filename} → {destination.name}")
+        elif on_collision == "overwrite":
+            print(f"Overwriting: {filename}")
+
+    if dry_run:
+        print(f"Would move: {filename} → {destination}")
+    else:
+        shutil.move(file_path, destination)
+        print(f"Moved: {filename} → {destination}")
+
+def organize_folder(path: str, dry_run=False, exclude=None, on_collision="skip"):
+    """Organiza los archivos de la carpeta según su extensión."""
     base = Path(path).expanduser().resolve()
     if not base.exists() or not base.is_dir():
         print(f"Path does not exist or is not a directory: {base}")
         return
 
+    # Patrones de exclusión (si no se especifican, se usan los predeterminados)
+    patterns = exclude if exclude else DEFAULT_EXCLUDES
+
     print(f"\nOrganizing folder: {base}")
+    print(f"Excluding patterns: {patterns}")
+    print(f"On collision policy: {on_collision}")
     files = os.listdir(base)
 
     stats = {}
@@ -26,45 +71,55 @@ def organize_folder(path: str):
         full_path = os.path.join(base, file)
 
         if os.path.isfile(full_path):
+            # Verificar exclusiones
+            if any(fnmatch.fnmatch(file, pattern) for pattern in patterns):
+                print(f"Excluded: {file}")
+                continue
+
             file_ext = os.path.splitext(file)[1].lower()
             moved = False
 
             for category, extensions in FILE_TYPES.items():
                 if file_ext in extensions:
-                    move_file(full_path, os.path.join(base, category))
+                    move_file(full_path, os.path.join(base, category), dry_run, on_collision)
                     stats[category] = stats.get(category, 0) + 1
                     total_processed += 1
                     moved = True
                     break
 
             if not moved:
-                move_file(full_path, os.path.join(base, "Others"))
+                move_file(full_path, os.path.join(base, "Others"), dry_run, on_collision)
                 stats["Others"] = stats.get("Others", 0) + 1
                 total_processed += 1
 
     print("\nOrganization completed.")
     print("\nSummary:")
-    print(f"Total files organized: {total_processed}")
+    print(f"Total files processed: {total_processed}")
     for category, count in stats.items():
         print(f"- {category}: {count}")
-
-def move_file(file_path, target_folder):
-    os.makedirs(target_folder, exist_ok=True)
-    filename = os.path.basename(file_path)
-    destination = os.path.join(target_folder, filename)
-    shutil.move(file_path, destination)
-    print(f"Moved: {filename} → {target_folder}")
 
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Organize files in a folder by category (Images, Documents, etc.)."
     )
     parser.add_argument("--path", required=True, help="Full path of the folder to organize")
+    parser.add_argument("--dry-run", action="store_true", help="Simulate actions without moving files")
+    parser.add_argument(
+        "--exclude",
+        nargs="+",
+        help="File patterns to exclude (e.g. *.tmp *.part). Defaults are used if not provided."
+    )
+    parser.add_argument(
+        "--on-collision",
+        choices=["skip", "overwrite", "rename"],
+        default="skip",
+        help="What to do if file exists: skip (default), overwrite, rename"
+    )
     return parser.parse_args()
 
 def main():
     args = parse_args()
-    organize_folder(args.path)
+    organize_folder(args.path, dry_run=args.dry_run, exclude=args.exclude, on_collision=args.on_collision)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Nuevo argumento --on-collision con 3 políticas:
  • skip (por defecto): no mueve si ya existe.
  • rename: crea una copia con sufijo (1), (2), etc.
  • overwrite: reemplaza el archivo existente.

- Compatibilidad total con --dry-run y --exclude.
- README.md actualizado con ejemplos de uso y documentación de la nueva opción.